### PR TITLE
Use GH_REPO in asset path

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -3,15 +3,16 @@
 // see http://vuejs-templates.github.io/webpack for documentation.
 
 const path = require('path')
-const {PROJECT_NAME, ...prodEnv} = require('./prod.env')
+
+console.log('GH_REPO', process.env.GH_REPO)
 
 module.exports = {
   build: {
-    env: prodEnv,
+    env: require('./prod.env'),
     index: path.resolve(__dirname, '../dist/index.html'),
     assetsRoot: path.resolve(__dirname, '../dist'),
     assetsSubDirectory: 'static',
-    assetsPublicPath: `${PROJECT_NAME}/`,
+    assetsPublicPath: process.env.GH_REPO ? `/${process.env.GH_REPO}/` : '/',
     productionSourceMap: true,
     // Gzip off by default as many popular static hosts such as
     // Surge or Netlify already gzip all static assets for you.

--- a/config/index.js
+++ b/config/index.js
@@ -4,8 +4,6 @@
 
 const path = require('path')
 
-console.log('GH_REPO', process.env.GH_REPO)
-
 module.exports = {
   build: {
     env: require('./prod.env'),

--- a/config/prod.env.js
+++ b/config/prod.env.js
@@ -3,6 +3,5 @@ module.exports = {
   NODE_ENV: '"production"',
   FETCH_HEADERS_API: `"https://fetch-headers.now.sh/"`,
   FETCH_MANIFEST_API: `"https://fetch-manifest.now.sh/"`,
-  WEBSHOT_API: `"https://webshot.now.sh/"`,
-  PROJECT_NAME: "manifiesta"
+  WEBSHOT_API: `"https://webshot.now.sh/"`
 }


### PR DESCRIPTION
This env variable is only set by Travis during CI build. Travis already uses this variable when deploying to GH Pages, so we can use this variable for the assets path in that situation.

Test using `GH_REPO=manifesta npm run build`.